### PR TITLE
Ajout CRC

### DIFF
--- a/dllCom/libcomm-emulslave-test/main.c
+++ b/dllCom/libcomm-emulslave-test/main.c
@@ -54,6 +54,7 @@ int main() {
 	assert(masterdata.lastCommand == proto_REPLY); // on a bien reçu une trame de réponse
 	assert(masterdata.lastArgs[0] == 218); // on a bien reçu la valeur attendue
 	
+	
 	// on réinitialise masterdata
 	masterdata.nbReceived = 0;
 	
@@ -67,6 +68,18 @@ int main() {
 	
 	assert(masterdata.lastCommand == proto_STATUS); // on a reçu une erreur de la part de l'esclave
 	assert(masterdata.lastArgs[0] == proto_INVALID_REGISTER);
+	
+	
+	proto_Frame frame = { 0 };
+	frame.header = proto_HEADER;
+	frame.crc = 0; // le CRC est pertinemment faux !
+	frame.command = proto_STATUS;
+	frame.args[0] = proto_NO_ERROR;
+	
+	proto_interpretBlob(&state, (void*)&frame, 4);
+	// Une erreur de CRC est normalement arrivée !
+	assert(masterdata.lastCommand == proto_NOTIF_BAD_CRC);
+	
 	
 	puts("Tous les tests ont réussi !");
 	

--- a/dllCom/libcomm/protocomm.c
+++ b/dllCom/libcomm/protocomm.c
@@ -2,10 +2,18 @@
 #include <string.h>
 #include <assert.h>
 
-
 static uint8_t getCRC(uint8_t const* data, uint8_t size) {
-	//TODO: À implémenter
-	return 0;
+    // plus d'info : https://en.wikipedia.org/wiki/Cyclic_redundancy_check#Computation
+    // implémentation de base : https://stackoverflow.com/a/51777726
+    unsigned crc = 0; // l'accumulateur pour les divisions
+    while (size--) {
+        crc ^= *data++; // on prend un nouvel octet de la séquence
+        for (unsigned k = 0; k < 8; k++) // pour chacun des 8 bits, dans l'ordre:
+            crc = crc & 0x80 ? // si le bit "actuel" est 1
+                    (crc << 1) ^ 0x31 : // on applique la division polynomiale
+                    crc << 1; // sinon on passe au bit suivant
+    }
+    return crc & 0xff; // on ne garde que les 8 bits de poids faibles
 }
 
 uint8_t proto_getArgsSize(proto_Command command) {


### PR DESCRIPTION
Implémentation de getCRC() dans le fichier protocomm.c (auparavant, retournait tout le temps 0).
+ Ajout d'un test dans libcomm-emulslave-test/main.c pour vérifier que le CRC fonctionne.